### PR TITLE
Add opcode when calculating Omni class

### DIFF
--- a/src/omnicore/wallettxbuilder.cpp
+++ b/src/omnicore/wallettxbuilder.cpp
@@ -57,7 +57,7 @@ int WalletTxBuilder(
 
     // Determine the class to send the transaction via - default is Class C
     int omniTxClass = OMNI_CLASS_C;
-    if (!UseEncodingClassC(payload.size())) omniTxClass = OMNI_CLASS_B;
+    if (!UseEncodingClassC(payload.size() + 1 /* OP_RETURN */ + 2 /* pushdata opcodes */)) omniTxClass = OMNI_CLASS_B;
 
     // Prepare the transaction - first setup some vars
     CCoinControl coinControl;


### PR DESCRIPTION
Data carrier size is set to 83 which includes the OP_RETURN and push data opcodes. When calculating the Omni TX class type these op codes are not being taken into consideration, so an 83 byte payload will be sent as an OP_RETURN output which will contain 86 bytes with the opcodes added.